### PR TITLE
decoration param added; warnings eliminated.

### DIFF
--- a/lib/flutter_custom_dialog.dart
+++ b/lib/flutter_custom_dialog.dart
@@ -17,6 +17,7 @@ class YYDialog {
   bool gravityAnimationEnable = false; //弹窗出现的位置带有的默认动画是否可用
   Color barrierColor = Colors.black.withOpacity(.3); //弹窗外的背景色
   Color backgroundColor = Colors.white; //弹窗内的背景色
+  Decoration decoration;
   double borderRadius = 0.0; //弹窗圆角
   BoxConstraints constraints; //弹窗约束
   Function(Widget child, Animation<double> animation) animatedFunc; //弹窗出现的动画
@@ -275,7 +276,7 @@ class YYDialog {
                 padding: EdgeInsets.all(borderRadius / 3.14),
                 width: width ?? null,
                 height: height ?? null,
-                decoration: BoxDecoration(
+                decoration: decoration ?? BoxDecoration(
                   borderRadius: BorderRadius.circular(borderRadius),
                   color: backgroundColor,
                 ),
@@ -384,10 +385,10 @@ class YYDialog {
 
 ///弹窗的内容作为可变组件
 class CustomDialogChildren extends StatefulWidget {
-  List<Widget> widgetList = []; //弹窗内部所有组件
-  Function(bool) isShowingChange;
+  final List<Widget> widgetList; //弹窗内部所有组件
+  final Function(bool) isShowingChange;
 
-  CustomDialogChildren({this.widgetList, this.isShowingChange});
+  CustomDialogChildren({this.widgetList = const [], this.isShowingChange});
 
   @override
   CustomDialogChildState createState() => CustomDialogChildState();

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -12,9 +12,9 @@ class YYRadioListTile extends StatefulWidget {
   })  : assert(items != null),
         super(key: key);
 
-  List<RadioItem> items;
-  Color activeColor;
-  Function(int) onChanged;
+  final List<RadioItem> items;
+  final Color activeColor;
+  final Function(int) onChanged;
 
   @override
   State<StatefulWidget> createState() {


### PR DESCRIPTION
Example:
```dart
dlg = YYDialog().build(context)
      ..gravity = Gravity.top
      ..width = double.infinity
      ..height = 350
      ..backgroundColor = Colors.teal
      ..decoration = BoxDecoration(
        gradient: LinearGradient(
          // Where the linear gradient begins and ends
          begin: Alignment.topRight,
          end: Alignment.bottomLeft,
          // Add one stop for each color. Stops should increase from 0 to 1
          stops: [0.1, 0.3, 0.5, 0.7, 0.9],
          colors: [
            Colors.teal[800],
            Colors.teal[700],
            Colors.teal[600],
            Colors.teal[500],
            Colors.teal[400],
          ],
        ),
      )
      ..barrierDismissible = false
      ..borderRadius = 0.0
```
produces the following result:
![image](https://user-images.githubusercontent.com/4129763/73510909-a759ed80-4398-11ea-98b9-29b5ae05966a.png)
