### PR TITLE
Color property removed

### DIFF
--- a/lib/flutter_custom_dialog.dart
+++ b/lib/flutter_custom_dialog.dart
@@ -207,6 +207,7 @@ class YYDialog {
     double height,
     Color activeColor,
     Function(int) onClickItemListener,
+    String selectedItem,
   }) {
     Size size = MediaQuery.of(context).size;
     return this.widget(
@@ -221,6 +222,7 @@ class YYDialog {
           items: items,
           activeColor: activeColor,
           onChanged: onClickItemListener,
+          selectedItem: selectedItem,
         ),
       ),
     );

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -33,7 +33,6 @@ class YYRadioListTileState extends State<YYRadioListTile> {
       itemCount: widget.items.length,
       itemBuilder: (BuildContext context, int index) {
         return Material(
-          color: Colors.white,
           child: RadioListTile(
             title: Text(widget.items[index].text),
             value: index,

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -38,7 +38,7 @@ class YYRadioListTileState extends State<YYRadioListTile> {
           child: RadioListTile(
             title: Text(widget.items[index].text),
             value: index,
-            selected: widget.items[index].text?.toLowerCase() == selectedItem?..toLowerCase(),
+            selected: widget.items[index].text?.toLowerCase() == selectedItem?.toLowerCase(),
             groupValue: groupId,
             activeColor: widget.activeColor,
             onChanged: (int value) {

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -39,7 +39,7 @@ class YYRadioListTileState extends State<YYRadioListTile> {
             title: Text(widget.items[index].text),
             value: index,
             selected: widget.items[index].text?.toLowerCase() == widget.selectedItem?.toLowerCase(),
-            groupValue: groupId,
+            groupValue: widget.items.indexWhere((item) => item.text?.toLowerCase() == widget.selectedItem?.toLowerCase()),
             activeColor: widget.activeColor,
             onChanged: (int value) {
               setState(() {

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -9,12 +9,14 @@ class YYRadioListTile extends StatefulWidget {
     this.items,
     this.activeColor,
     this.onChanged,
+    this.selectedItem,
   })  : assert(items != null),
         super(key: key);
 
   final List<RadioItem> items;
   final Color activeColor;
   final Function(int) onChanged;
+  final String selectedItem;
 
   @override
   State<StatefulWidget> createState() {
@@ -36,6 +38,7 @@ class YYRadioListTileState extends State<YYRadioListTile> {
           child: RadioListTile(
             title: Text(widget.items[index].text),
             value: index,
+            selected: widget.items[index].text?.toLowerCase() == selectedItem?..toLowerCase()
             groupValue: groupId,
             activeColor: widget.activeColor,
             onChanged: (int value) {

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -38,7 +38,7 @@ class YYRadioListTileState extends State<YYRadioListTile> {
           child: RadioListTile(
             title: Text(widget.items[index].text),
             value: index,
-            selected: widget.items[index].text?.toLowerCase() == selectedItem?.toLowerCase(),
+            selected: widget.items[index].text?.toLowerCase() == widget.selectedItem?.toLowerCase(),
             groupValue: groupId,
             activeColor: widget.activeColor,
             onChanged: (int value) {

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -25,7 +25,9 @@ class YYRadioListTile extends StatefulWidget {
 }
 
 class YYRadioListTileState extends State<YYRadioListTile> {
-  var groupId = 0;
+  String selectedItem = widget.selectedItem;
+  var groupId = widget.items.indexWhere((item) => item.text?.toLowerCase() == selectedItem?.toLowerCase());
+
 
   @override
   Widget build(BuildContext context) {
@@ -38,13 +40,14 @@ class YYRadioListTileState extends State<YYRadioListTile> {
           child: RadioListTile(
             title: Text(widget.items[index].text),
             value: index,
-            selected: widget.items[index].text?.toLowerCase() == widget.selectedItem?.toLowerCase(),
-            groupValue: widget.items.indexWhere((item) => item.text?.toLowerCase() == widget.selectedItem?.toLowerCase()),
+            selected: widget.items[index].text?.toLowerCase() == selectedItem?.toLowerCase(),
+            groupValue: groupId,
             activeColor: widget.activeColor,
             onChanged: (int value) {
               setState(() {
                 widget.onChanged(value);
                 groupId = value;
+                selectedItem = widget.items[value];
               });
             },
           ),

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -38,7 +38,7 @@ class YYRadioListTileState extends State<YYRadioListTile> {
           child: RadioListTile(
             title: Text(widget.items[index].text),
             value: index,
-            selected: widget.items[index].text?.toLowerCase() == selectedItem?..toLowerCase()
+            selected: widget.items[index].text?.toLowerCase() == selectedItem?..toLowerCase(),
             groupValue: groupId,
             activeColor: widget.activeColor,
             onChanged: (int value) {

--- a/lib/flutter_custom_dialog_widget.dart
+++ b/lib/flutter_custom_dialog_widget.dart
@@ -25,9 +25,15 @@ class YYRadioListTile extends StatefulWidget {
 }
 
 class YYRadioListTileState extends State<YYRadioListTile> {
-  String selectedItem = widget.selectedItem;
-  var groupId = widget.items.indexWhere((item) => item.text?.toLowerCase() == selectedItem?.toLowerCase());
+  String selectedItem;
+  int groupId = 0;
 
+  @override
+  void initState() {
+    super.initState();
+    selectedItem = widget.selectedItem;
+    groupId = widget.items.indexWhere((item) => item.text?.toLowerCase() == widget.selectedItem?.toLowerCase());
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +53,7 @@ class YYRadioListTileState extends State<YYRadioListTile> {
               setState(() {
                 widget.onChanged(value);
                 groupId = value;
-                selectedItem = widget.items[value];
+                selectedItem = widget.items[value].text;
               });
             },
           ),


### PR DESCRIPTION
Removed the color property in Material widget. It shouldn't be hardcoded cause it may create an issue with dark themed apps. 